### PR TITLE
added check for null scheduler

### DIFF
--- a/src/main/java/com/github/kilianB/uPnPClient/UPnPDevice.java
+++ b/src/main/java/com/github/kilianB/uPnPClient/UPnPDevice.java
@@ -574,9 +574,11 @@ public class UPnPDevice {
 	/**
 	 * Shutdown non daemon threads ot the upnp device
 	 */
-	public void deinit() {
-		scheduler.shutdownNow();
-	}
+        public void deinit() {
+                if(scheduler != null) {
+                        scheduler.shutdownNow();
+                }
+        }
 	
 	private Thread handleShutdown = new Thread(() -> {
 

--- a/src/main/java/com/github/kilianB/uPnPClient/UPnPDevice.java
+++ b/src/main/java/com/github/kilianB/uPnPClient/UPnPDevice.java
@@ -574,11 +574,11 @@ public class UPnPDevice {
 	/**
 	 * Shutdown non daemon threads ot the upnp device
 	 */
-        public void deinit() {
-                if(scheduler != null) {
-                        scheduler.shutdownNow();
-                }
-        }
+	public void deinit() {
+		if(scheduler != null) {
+			scheduler.shutdownNow();
+		}
+	}
 	
 	private Thread handleShutdown = new Thread(() -> {
 
@@ -613,3 +613,4 @@ public class UPnPDevice {
 	}
 
 }
+


### PR DESCRIPTION
found an issue in `UPnPDevice.java`; the scheduler is not tested to see if it's assigned to `null` before `shutdownNow` is called.